### PR TITLE
fixed Cleft of Shadow marked as Dungeon

### DIFF
--- a/Guidelime/Data/Guidelime_MapDB.lua
+++ b/Guidelime/Data/Guidelime_MapDB.lua
@@ -206,7 +206,7 @@ else
 	 ["Winterspring"]=83,
 	 ["Stormwind City"]=84,
 	 ["Orgrimmar"]=85,
-	 ["Cleft of Shadow@Orgrimmar!Dungeon"]=86,
+	 ["Cleft of Shadow"]=86,
 	 ["Ironforge!Eastern Kingdoms"]=87,
 	 ["Thunder Bluff"]=88,
 	 ["Darnassus"]=89,


### PR DESCRIPTION
Fixes loading error for coordinates in Cleft of Shadow:
![image](https://user-images.githubusercontent.com/6736635/63632265-349f5600-c633-11e9-93d0-a2b6bfe4f591.png)
