### PR TITLE
Fixing some wrong quest pre-requisites

### DIFF
--- a/Guidelime/Data/Guidelime_QuestsDB.lua
+++ b/Guidelime/Data/Guidelime_QuestsDB.lua
@@ -18113,7 +18113,6 @@ addon.questsDB = {
 	      };
 	   };
 	   ["name"] = "The Captain's Chest";
-	   ["faction"] = "Alliance";
 	   ["level"] = 45;
 	   ["source"] = {
 	      [1] = {
@@ -18126,7 +18125,6 @@ addon.questsDB = {
 	[615] = {
 	   ["objective"] = "Speak with Sprogger.";
 	   ["zone"] = "Stranglethorn Vale";
-	   ["faction"] = "Alliance";
 	   ["name"] = "The Captain's Cutlass";
 	   ["next"] = 618;
 	   ["sort"] = "Stranglethorn Vale";
@@ -31866,7 +31864,7 @@ addon.questsDB = {
 	   ["req"] = 50;
 	};
 	[5237] = {
-	   ["faction"] = "Horde";
+	   ["faction"] = "Alliance";
 	   ["name"] = "Mission Accomplished!";
 	   ["objective"] = "";
 	   ["zone"] = "Western Plaguelands";
@@ -33100,7 +33098,6 @@ addon.questsDB = {
 	[8553] = {
 	   ["objective"] = "Speak with Sprogger.";
 	   ["zone"] = "Stranglethorn Vale";
-	   ["faction"] = "Horde";
 	   ["name"] = "The Captain's Cutlass";
 	   ["next"] = 8554;
 	   ["sort"] = "Stranglethorn Vale";
@@ -37154,7 +37151,7 @@ addon.questsDB = {
 	   ["req"] = 50;
 	};
 	[5238] = {
-	   ["faction"] = "Alliance";
+	   ["faction"] = "Horde";
 	   ["name"] = "Mission Accomplished!";
 	   ["objective"] = "";
 	   ["zone"] = "Western Plaguelands";
@@ -124421,7 +124418,6 @@ addon.questsDB = {
 	};
 	[5092] = {
 	   ["name"] = "Clear the Way";
-	   ["oneOfPrequests"] = true;
 	   ["objective"] = "Kill 10 Skeletal Flayers and 10 Slavering Ghouls in Sorrow Hill.$B$BReturn to Commander Ashlam Valorfist at Chillwind Camp, Western Plaguelands.";
 	   ["zone"] = "Western Plaguelands";
 	   ["sort"] = "Western Plaguelands";
@@ -124439,11 +124435,6 @@ addon.questsDB = {
 	      };
 	   };
 	   ["faction"] = "Alliance";
-	   ["prequests"] = {
-	      [1] = 5090;
-	      [2] = 5066;
-	      [3] = 5091;
-	   };
 	   ["level"] = 52;
 	   ["source"] = {
 	      [1] = {
@@ -126722,7 +126713,6 @@ addon.questsDB = {
 	      };
 	   };
 	   ["name"] = "The Captain's Chest";
-	   ["faction"] = "Horde";
 	   ["level"] = 47;
 	   ["source"] = {
 	      [1] = {

--- a/Guidelime/Data/Guidelime_QuestsDB.lua
+++ b/Guidelime/Data/Guidelime_QuestsDB.lua
@@ -10274,9 +10274,6 @@ addon.questsDB = {
 	      };
 	   };
 	   ["prev"] = 1097;
-	   ["prequests"] = {
-	      [1] = 1097;
-	   };
 	   ["level"] = 15;
 	   ["source"] = {
 	      [1] = {


### PR DESCRIPTION
Fixes wrong pre-requisites for the following quests:

The Captain's Chest
The Captain's Cutlass
Mission Accomplished! (Horde and Alliance versions)
Clear the Way

`/lime quests` report:
https://pastebin.com/Yu4AF1Lj

Fixes issue #119