### PR TITLE
Adding a new feature to allow step completion based on item collection

### DIFF
--- a/Guidelime/Guidelime.lua
+++ b/Guidelime/Guidelime.lua
@@ -819,7 +819,7 @@ local function updateStepCompletion(i, completedIndexes)
 				end
 			end
 			if step.completed == nil or not element.completed then step.completed = element.completed end
-            autoCompleteStep = true
+			autoCompleteStep = true
 		elseif element.t == "COLLECT_ITEM" and step.active then
 			if GetItemCount(element.itemId) >= element.qty then
 				element.completed = true
@@ -829,6 +829,7 @@ local function updateStepCompletion(i, completedIndexes)
 				step.itemsCollected = false
 			end
 			if step.completed == nil or not element.completed then step.completed = element.completed end
+			autoCompleteStep = true
 		end
 	end
 	-- check goto last so that go to does not matter when all other objectives are completed

--- a/Guidelime/Guidelime.lua
+++ b/Guidelime/Guidelime.lua
@@ -685,10 +685,10 @@ function addon.getStepText(step)
 				end
 			end
 		elseif element.t == "COLLECT_ITEM" then
-		local name,_,rarity = GetItemInfo(element.itemId)
-		local count,icon
-		local textIcon = "|T" .. addon.icons.item .. ":12|t"
-		local colour = ITEM_QUALITY_COLORS[1].hex
+			local name,_,rarity = GetItemInfo(element.itemId)
+			local count,icon
+			local textIcon = "|T" .. addon.icons.item .. ":12|t"
+			local colour = ITEM_QUALITY_COLORS[1].hex
 			if name then
 				if step.active then
 					count = GetItemCount(element.itemId)

--- a/Guidelime/Guidelime.toc
+++ b/Guidelime/Guidelime.toc
@@ -1,6 +1,6 @@
 ## Title: Guidelime
 ## Author: Borick of Arthas(EU)
-## Version: 1.042
+## Version: 1.043
 ## Interface: 11305
 ## SavedVariables: GuidelimeData
 ## SavedVariablesPerCharacter: GuidelimeDataChar

--- a/Guidelime/Guidelime_Events.lua
+++ b/Guidelime/Guidelime_Events.lua
@@ -384,3 +384,22 @@ function addon.frame:PLAYER_UNGHOST()
 	if addon.debugging then print ("LIME: PLAYER_UNGHOST") end
 	addon.alive = true
 end
+
+addon.requestItemInfo = {}
+addon.frame:RegisterEvent('GET_ITEM_INFO_RECEIVED')
+function addon.frame:GET_ITEM_INFO_RECEIVED(itemId,success)
+	if addon.debugging then print ("LIME: GET_ITEM_INFO_RECEIVED") end
+	if addon.requestItemInfo[itemId] and success then
+		addon.requestItemInfo[itemId] = nil
+		addon.updateStepsText()
+	end
+end
+
+addon.frame:RegisterEvent('BAG_UPDATE')
+function addon.frame:BAG_UPDATE()
+	if addon.debugging then print ("LIME: BAG_UPDATE") end
+	local guide = addon.guides[GuidelimeDataChar.currentGuide]
+	if guide and guide.itemUpdateIndices and #guide.itemUpdateIndices > 0 then
+		addon.updateSteps(guide.itemUpdateIndices)
+	end
+end

--- a/Guidelime/Guidelime_Parser.lua
+++ b/Guidelime/Guidelime_Parser.lua
@@ -53,6 +53,7 @@ addon.codes = {
 	COMPLETE_WITH_NEXT = "C", -- same as OC
 	PICKUP = "QP", -- same as QA
 	WORK = "QW", -- same as QC but optional
+	COLLECT_ITEM = "CI",
 }
 
 addon.COLOR_INACTIVE = "|cFF666666"
@@ -82,6 +83,7 @@ function addon.parseGuide(guide, group, strict, nameOnly)
 		guide.lines = 1
 		guide.steps = {}
 		guide.next = {}
+		guide.itemUpdateIndices = {}
 		guide.autoAddCoordinatesGOTO = true
 		guide.autoAddCoordinatesLOC = true
 		local t = guide.text:gsub("\\\\[\n\r]", "\\\\"):gsub("([^\n\r]-)[\n\r]", function(c)
@@ -416,6 +418,22 @@ function addon.parseLine(step, guide, strict, nameOnly)
 --					err = true
 --				end
 			end
+		elseif element.t == "COLLECT_ITEM" then
+			local _, c = tag:gsub("%s*(%d+),?(%d*)%s*(.-)%s*$", function(id, qty, title)	
+				if id ~= "" then
+					element.itemRequests = 0
+					element.itemId = tonumber(id)
+					element.qty = tonumber(qty) or 1
+					if title == "-" then
+						element.title = ""
+					elseif title ~= "" then
+						element.title = title
+					end
+				else
+					addon.createPopupFrame(string.format(L.ERROR_CODE_NOT_RECOGNIZED, guide.title or "", code, (step.line or "") .. " " .. step.text)):Show()
+					err = true
+				end
+			end, 1)
 		else
 			element.text, element.textInactive = textFormatting(tag)
 		end


### PR DESCRIPTION
I propose adding a new feature, COLLECT_ITEM or CI, where you can use it to track specific items, for instance, if you want to make sure to have 15 silk cloth before starting searing gorge, which is used later on for a quest that you don't have at the moment you start the guide.

```
Make sure you have 15 [CI4306,15 Silk Cloth] on your bags before starting this segment
```
Which produces:

![image](https://user-images.githubusercontent.com/26726709/108613022-7a75df80-73cc-11eb-94ee-226e62649acc.png)

and the step will auto complete as soon as you have 15 silk cloth in your bags

The usage follows the same Guidelime syntax for quest completion, where [CI4306] will fill in the localized name automatically and [CI4306-] will only show the icon and omit the item name entirely

Unlike the QUEST_COMPLETE auto complete routine, it's important to execute the step completion check only if the step is active, because this relies on the  GetItemCount() function that only works for items in your bags, to prevent the step coming back up when you equip an item or deposit it.