### PR TITLE
Flight path automation for connected flight paths

### DIFF
--- a/Guidelime/Guidelime_Events.lua
+++ b/Guidelime/Guidelime_Events.lua
@@ -378,6 +378,8 @@ function addon.frame:TAXIMAP_OPENED()
 									if IsMounted() then Dismount() end -- dismount before using the flightpoint
 									if addon.debugging then print ("LIME: Flying to " .. (master.place or master.zone)) end
 									C_Timer.After(0.5, function()
+										local taxiButton = getglobal("TaxiButton"..j)
+										taxiButton:GetScript("OnEnter")(taxiButton)
 										TakeTaxiNode(j)
 									end)
 									addon.completeSemiAutomatic(element)


### PR DESCRIPTION
Right now there is a bug where flight paths with more than 1 leg are not contemplated by the FP automation feature, this is a simple fix for the issue.