### PR TITLE
new Applies features: Item possession

### DIFF
--- a/Guidelime/Data/Data.lua
+++ b/Guidelime/Data/Data.lua
@@ -236,35 +236,13 @@ function D.hasbit(x, p)
 end
 
 function D.hasItem(itemReq, itemMin, itemMax)
-	if not itemReq then return nil end
-	
-	local itemid = tonumber(itemReq)
-	local itemcnt = 0
+	-- note that itemMin is not "minimum number of items", but "greater than" (not "greater or equal"), analog itemMax
+	-- as pattern match for element.t == "APPLIES" in GuideParser.lua does not allow for <= or >=
 
-	-- note: will NOT scan for items in bank or mailbox, even if opened
-	-- look into KEYRING_CONTAINER (special ID) first
-	for slot = 1, C_Container.GetContainerNumSlots(KEYRING_CONTAINER) do
-		local item = C_Container.GetContainerItemInfo(KEYRING_CONTAINER, slot)
-		if item and tonumber(item["itemID"]) == tonumber(itemid) then
-			itemcnt = itemcnt + tonumber(item["stackCount"])
-			-- if we dont' have a max limit and already found what we need, don't bother looking further
-			if itemMin and itemcnt >= itemMin then return true end
-		end
-	end
-	-- look into all bags
-	for bag = BACKPACK_CONTAINER, NUM_BAG_SLOTS do
-		for slot = 1, C_Container.GetContainerNumSlots(bag) do
-			local item = C_Container.GetContainerItemInfo(bag, slot)
-			if item and tonumber(item["itemID"]) == tonumber(itemid) then
-				itemcnt = itemcnt + tonumber(item["stackCount"])
-				-- if we dont' have a max limit and already found what we need, don't bother looking further
-				if itemMin and itemcnt >= itemMin then return true end
-			end
-		end
-	end
-	
-	-- itemMin was already checked as last command in for loop, so let's look at itemMax
-	if itemMax and itemcnt <= itemMax then return true end
-	
-	return false
+	local itemcnt = GetItemCount(tonumber(itemReq))
+
+	if itemMin ~= nil then return (itemcnt > itemMin) end
+	if itemMax ~= nil then return (itemcnt < itemMax) end
+
+	return nil
 end

--- a/Guidelime/GuideParser.lua
+++ b/Guidelime/GuideParser.lua
@@ -435,13 +435,18 @@ function GP.parseLine(step, guide, strict, nameOnly)
 					if step.spellMin == nil and step.spellMax == nil then step.spellMin = 1 end
 				elseif c == "IT" and value1 ~= "" then
 					step.itemReq = tonumber(value1)
+					-- note that itemMin is not "minimum number of items", but "greater than" (not "greater or equal"), analog itemMax
 					if less == "<" then
-						step.itemMax = tonumber(value2)
-					else
-						step.itemMin = tonumber(value2)
+						-- if value2 is not filled, assume we don't want that item at all, so <1
+						step.itemMax = tonumber(value2) or 1
+					elseif less == ">" then
+						-- if value2 is not filled, assume we want at least one of these items, so >0
+						step.itemMin = tonumber(value2) or 0
 					end
-					-- if none specified at least one item is required
-					if step.itemMin == nil and step.itemMax == nil then step.itemMin = 1 end
+					-- if neither min nor max is set, check for "exists", that is: at least one, so >0
+					if step.itemMin == nil and step.itemMax == nil then
+						step.itemMin = 0
+					end
 				elseif value1 ~= "" and (less ~= "" or value2 ~= "") then
 					F.createPopupFrame(string.format(L.ERROR_CODE_NOT_RECOGNIZED, guide.title or "", code, (step.line or "") .. " " .. step.text)):Show()
 					err = true

--- a/Guidelime/GuideParser.lua
+++ b/Guidelime/GuideParser.lua
@@ -433,6 +433,15 @@ function GP.parseLine(step, guide, strict, nameOnly)
 					end
 					-- if none specified spell rank 1 is required
 					if step.spellMin == nil and step.spellMax == nil then step.spellMin = 1 end
+				elseif c == "IT" and value1 ~= "" then
+					step.itemReq = tonumber(value1)
+					if less == "<" then
+						step.itemMax = tonumber(value2)
+					else
+						step.itemMin = tonumber(value2)
+					end
+					-- if none specified at least one item is required
+					if step.itemMin == nil and step.itemMax == nil then step.itemMin = 1 end
 				elseif value1 ~= "" and (less ~= "" or value2 ~= "") then
 					F.createPopupFrame(string.format(L.ERROR_CODE_NOT_RECOGNIZED, guide.title or "", code, (step.line or "") .. " " .. step.text)):Show()
 					err = true


### PR DESCRIPTION
[A IT12382] or [A IT12382>0] is: if user owns "Key to the City"; or [A IT12382<1] is: does not own.
Not evaluated on the fly, but only on opening the guide