### PR TITLE
fix: Fixes highlighting wowhead url

### DIFF
--- a/Guidelime/Frames.lua
+++ b/Guidelime/Frames.lua
@@ -212,7 +212,7 @@ function F.showCopyPopup(value, text, textwidth, height, multiline)
 	popup.textbox:SetPoint("TOPLEFT", 20 + textwidth, -20)
 	popup.textbox:SetText(value)
 	popup.textbox:SetFocus()
-	popup.textbox:HighlightText(false)
+	popup.textbox:HighlightText()
 	popup:Show()
 	return popup
 end


### PR DESCRIPTION
The API for highlighting text must have changed. This now highlights all the text when opening the wowhead URL for quests.