### PR TITLE
Fix deprecated API calls for WoW Anniversary Edition

### DIFF
--- a/Guidelime/Editor.lua
+++ b/Guidelime/Editor.lua
@@ -889,7 +889,7 @@ function E.showEditor()
 		E.editorFrame.okBtn:SetText(nil)
 		
 		E.editorFrame.title = E.editorFrame:CreateFontString(nil, "ARTWORK", "GameFontNormal")
-		E.editorFrame.title:SetText(GetAddOnMetadata(addonName, "title") .. " |cFFFFFFFF" .. GetAddOnMetadata(addonName, "version") .." - " .. L.EDITOR)
+		E.editorFrame.title:SetText(C_AddOns.GetAddOnMetadata(addonName, "title") .. " |cFFFFFFFF" .. C_AddOns.GetAddOnMetadata(addonName, "version") .." - " .. L.EDITOR)
 		E.editorFrame.title:SetPoint("TOPLEFT", 20, -20)
 		E.editorFrame.title:SetFontObject("GameFontNormalLarge")
 		local prev = E.editorFrame.title

--- a/Guidelime/Events.lua
+++ b/Guidelime/Events.lua
@@ -624,19 +624,6 @@ function EV.frame:UNIT_SPELLCAST_SUCCEEDED(unitTarget, castGUID, spellID)
 	end)
 end
 
-EV.frame:RegisterEvent('LEARNED_SPELL_IN_TAB')
-function EV.frame:LEARNED_SPELL_IN_TAB(spellID, skillInfoIndex, isGuildPerkSpell)
-	if addon.debugging then print("LIME: LEARNED_SPELL_IN_TAB", spellID, skillInfoIndex, isGuildPerkSpell) end
-	local found = false
-	CG.forEveryActiveElement(function(element)
-		if element.t == "LEARN" and element.spellId == spellID then
-			found = true
-			return false
-		end
-	end)
-	if found then CG.updateSteps() end
-end
-
 EV.frame:RegisterEvent('SKILL_LINES_CHANGED')
 function EV.frame:SKILL_LINES_CHANGED()
 	if addon.debugging then print("LIME: SKILL_LINES_CHANGED") end

--- a/Guidelime/Guidelime.lua
+++ b/Guidelime/Guidelime.lua
@@ -130,7 +130,7 @@ function addon.loadData()
 		targetRaidMarkers = true,
 		autoSelectStartGuide = true,
 		fontColorInactive = addon.MW.COLOR_INACTIVE,
-		version = GetAddOnMetadata(addonName, "version")
+		version = C_AddOns.GetAddOnMetadata(addonName, "version")
 	}
 	local defaultOptionsChar = {
 		mainFrameX = 0,
@@ -160,7 +160,7 @@ function addon.loadData()
 		guidesFrameX = 0,
 		guidesFrameY = 0,
 		guidesFrameRelative = "CENTER",
-		version = GetAddOnMetadata(addonName, "version"),
+		version = C_AddOns.GetAddOnMetadata(addonName, "version"),
 		showTargetButtons = "LEFT",
 		showUseItemButtons = "LEFT",
 		showMinimapButton = true,
@@ -196,7 +196,7 @@ function addon.loadData()
 		if tonumber(major) < 1 or (tonumber(major) == 1 and tonumber(minor) < 2) then
 			--changed default value for showUnavailableSteps
 			GuidelimeDataChar.showUnavailableSteps = true
-			GuidelimeDataChar.version = GetAddOnMetadata(addonName, "version")
+			GuidelimeDataChar.version = C_AddOns.GetAddOnMetadata(addonName, "version")
 		end
 		if tonumber(major) == 0 and tonumber(minor) < 41 then
 			GuidelimeDataChar.autoCompleteQuest = nil
@@ -218,7 +218,7 @@ function addon.loadData()
 			GuidelimeData.autoAcceptQuests = (GuidelimeData.autoCompleteQuest ~= false and "Current") or false
 			GuidelimeData.autoTurnInQuests = GuidelimeData.autoAcceptQuests
 			GuidelimeData.autoCompleteQuest = nil
-			GuidelimeData.version = GetAddOnMetadata(addonName, "version")
+			GuidelimeData.version = C_AddOns.GetAddOnMetadata(addonName, "version")
 		end
 		if tonumber(major) < 2 or (tonumber(major) == 2 and tonumber(minor) < 15) then
 			-- dataSourceQuestie is removed and replaced with dataSource which should be set to "QUESTIE"
@@ -407,7 +407,7 @@ function addon.checkQuests()
 		text = "Reported by " .. (UnitName("player") or "?") .. "-" .. (GetRealmName() or "?")  .. "(" .. regions[GetCurrentRegion() or 6] .. "), " .. 
 			(addon.D.level or "?")  .. " " .. (addon.D.race or "?")  .. " " .. (addon.D.class or "?")  .. "," ..
 			" at " .. date("%Y/%m/%d %H:%M:%S", GetServerTime()) .. 
-			" with " .. GetAddOnMetadata(addonName, "title") .. " " .. GetAddOnMetadata(addonName, "version") .. "\r\n" .. text
+			" with " .. C_AddOns.GetAddOnMetadata(addonName, "title") .. " " .. C_AddOns.GetAddOnMetadata(addonName, "version") .. "\r\n" .. text
 		text = string.format(L.CHECK_QUESTS, addon.CONTACT_DISCORD, addon.CONTACT_CURSEFORGE, addon.CONTACT_REDDIT) .. "\r\n" .. text
 		text = string.format(L.CHECK_QUESTS_COMPLETED, count) .. ".\r" .. text
 		local popup = addon.F.showCopyPopup(text, "", 0, 500, true)

--- a/Guidelime/Guides.lua
+++ b/Guidelime/Guides.lua
@@ -86,7 +86,7 @@ function G.showGuides()
 		G.guidesFrame.okBtn:SetText(nil)
 	
 		G.guidesFrame.title = G.guidesFrame:CreateFontString(nil, "ARTWORK", "GameFontNormal")
-		G.guidesFrame.title:SetText(GetAddOnMetadata(addonName, "title") .. " |cFFFFFFFF" .. GetAddOnMetadata(addonName, "version"))
+		G.guidesFrame.title:SetText(C_AddOns.GetAddOnMetadata(addonName, "title") .. " |cFFFFFFFF" .. C_AddOns.GetAddOnMetadata(addonName, "version"))
 		G.guidesFrame.title:SetPoint("TOPLEFT", G.guidesFrame, "TOPLEFT", 20, -20)
 		G.guidesFrame.title:SetFontObject("GameFontNormalLarge")
 		local prev = G.guidesFrame.title

--- a/Guidelime/Options.lua
+++ b/Guidelime/Options.lua
@@ -55,7 +55,7 @@ function O.fillOptions()
 	end
 
 	O.optionsFrame.title = O.optionsFrame:CreateFontString(nil, "ARTWORK", "GameFontNormal")
-	O.optionsFrame.title:SetText(GetAddOnMetadata(addonName, "title") .. " |cFFFFFFFF" .. GetAddOnMetadata(addonName, "version") .." - " .. GAMEOPTIONS_MENU)
+	O.optionsFrame.title:SetText(C_AddOns.GetAddOnMetadata(addonName, "title") .. " |cFFFFFFFF" .. C_AddOns.GetAddOnMetadata(addonName, "version") .." - " .. GAMEOPTIONS_MENU)
 	O.optionsFrame.title:SetPoint("TOPLEFT", 20, -20)
 	O.optionsFrame.title:SetFontObject("GameFontNormalLarge")
 	local prev = O.optionsFrame.title


### PR DESCRIPTION
This PR fixes two deprecated API issues that prevent Guidelime from loading on WoW Anniversary Edition (and likely other modern Classic clients).

  Issues Fixed

  1. GetAddOnMetadata is nil
  Guidelime/Guidelime.lua:133: attempt to call global 'GetAddOnMetadata' (a nil value)
  Blizzard moved this function to the C_AddOns namespace. Updated all 10 occurrences across 4 files to use C_AddOns.GetAddOnMetadata().

  2. Unknown event LEARNED_SPELL_IN_TAB
  Attempt to register unknown event "LEARNED_SPELL_IN_TAB"
  This event was removed from the game. The handler has been removed since spell/skill changes are already covered by SKILL_LINES_CHANGED.

  Changes

  | File          | Change                                                      |
  |---------------|-------------------------------------------------------------|
  | Guidelime.lua | GetAddOnMetadata → C_AddOns.GetAddOnMetadata (4×)           |
  | Editor.lua    | GetAddOnMetadata → C_AddOns.GetAddOnMetadata (2×)           |
  | Guides.lua    | GetAddOnMetadata → C_AddOns.GetAddOnMetadata (2×)           |
  | Options.lua   | GetAddOnMetadata → C_AddOns.GetAddOnMetadata (2×)           |
  | Events.lua    | Removed LEARNED_SPELL_IN_TAB event registration and handler |

  Tested on WoW Anniversary Edition TBC - addon loads without errors and guide functionality works as expected.

  ---
  Thanks for maintaining Guidelime! It's been super helpful for leveling. Happy to make any adjustments if needed.